### PR TITLE
ROCANA-7368: netflow respects observation domain / source id

### DIFF
--- a/ipfix/translate.go
+++ b/ipfix/translate.go
@@ -30,9 +30,10 @@ func (t *Translate) Record(dr *DataRecord) error {
 		tr TemplateRecord
 		ok bool
 	)
-	if tm, ok = t.Session.GetTemplate(dr.TemplateID); !ok {
+	if tm, ok = t.Session.GetTemplate(dr.TemplateID, dr.ObservationDomainID); !ok {
 		if debug {
-			debugLog.Printf("no template for id=%d, can't translate field\n", dr.TemplateID)
+			debugLog.Printf("no template for id=%d, observationDomainID=%d, can't translate field\n",
+				dr.TemplateID, dr.ObservationDomainID)
 		}
 		return nil
 	}
@@ -41,7 +42,8 @@ func (t *Translate) Record(dr *DataRecord) error {
 	}
 	if tr.Fields == nil {
 		if debug {
-			debugLog.Printf("no fields in template id=%d, can't translate\n", dr.TemplateID)
+			debugLog.Printf("no fields in template id=%d, observationDomainID=%d, can't translate\n",
+				dr.TemplateID, dr.ObservationDomainID)
 		}
 		return nil
 	}

--- a/netflow9/packet.go
+++ b/netflow9/packet.go
@@ -135,7 +135,7 @@ func (p *Packet) UnmarshalFlowSets(r io.Reader, s session.Session, t *Translate)
 				dfs.Bytes = data
 				continue
 			}
-			if tm, ok = s.GetTemplate(header.ID); !ok {
+			if tm, ok = s.GetTemplate(header.ID, p.Header.SourceID); !ok {
 				if debug {
 					debugLog.Printf("no template for id=%d, storing %d raw bytes in data set\n", header.ID, len(data))
 				}
@@ -274,6 +274,7 @@ func (tfs *TemplateFlowSet) UnmarshalRecords(r io.Reader) error {
 // TemplateRecord is a Template Record as per RFC3964 section 5.2
 type TemplateRecord struct {
 	TemplateID uint16
+	SourceID   uint32
 	FieldCount uint16
 	Fields     FieldSpecifiers
 }
@@ -290,8 +291,12 @@ func (tr TemplateRecord) register(s session.Session) {
 	s.AddTemplate(tr)
 }
 
-func (tr TemplateRecord) ID() uint16 {
+func (tr TemplateRecord) TID() uint16 {
 	return tr.TemplateID
+}
+
+func (tr TemplateRecord) OID() uint32 {
+	return tr.SourceID
 }
 
 func (tr TemplateRecord) String() string {
@@ -406,6 +411,7 @@ func (dfs *DataFlowSet) Unmarshal(r io.Reader, tr TemplateRecord, t *Translate) 
 	for buffer.Len() >= 4 {
 		var dr = DataRecord{}
 		dr.TemplateID = tr.TemplateID
+		dr.SourceID = tr.SourceID
 		if err := dr.Unmarshal(bytes.NewBuffer(buffer.Next(tr.Size())), tr.Fields, t); err != nil {
 			return err
 		}
@@ -417,6 +423,7 @@ func (dfs *DataFlowSet) Unmarshal(r io.Reader, tr TemplateRecord, t *Translate) 
 
 type DataRecord struct {
 	TemplateID uint16
+	SourceID   uint32
 	Fields     Fields
 }
 

--- a/netflow9/translate.go
+++ b/netflow9/translate.go
@@ -38,9 +38,10 @@ func (t *Translate) Record(dr *DataRecord) error {
 		tr TemplateRecord
 		ok bool
 	)
-	if tm, ok = t.Session.GetTemplate(dr.TemplateID); !ok {
+	if tm, ok = t.Session.GetTemplate(dr.TemplateID, dr.SourceID); !ok {
 		if debug {
-			debugLog.Printf("no template for id=%d, can't translate field\n", dr.TemplateID)
+			debugLog.Printf("no template for id=%d, sourceID=%d, can't translate field\n",
+				dr.TemplateID, dr.SourceID)
 		}
 		return nil
 	}
@@ -49,7 +50,8 @@ func (t *Translate) Record(dr *DataRecord) error {
 	}
 	if tr.Fields == nil {
 		if debug {
-			debugLog.Printf("no fields in template id=%d, can't translate\n", dr.TemplateID)
+			debugLog.Printf("no fields in template id=%d, sourceID=%d, can't translate\n",
+				dr.TemplateID, dr.SourceID)
 		}
 		return nil
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,61 @@
+package session
+
+import (
+	"testing"
+)
+
+type MockTemplate struct {
+	tid uint16
+	oid uint32
+}
+
+func (m *MockTemplate) ID() uint64 {
+	return uint64(m.tid)<<32 | uint64(m.oid)
+}
+
+func (m *MockTemplate) TID() uint16 {
+	return m.tid
+}
+
+func (m *MockTemplate) OID() uint32 {
+	return m.oid
+}
+
+func TestSession(t *testing.T) {
+	m := &MockTemplate{tid: uint16(1), oid: uint32(2)}
+	s := New()
+	s.AddTemplate(m)
+	template, found := s.GetTemplate(m.TID(), m.OID())
+	if !found {
+		t.Fatal("Couldn't find expected template")
+	}
+	if template.TID() != uint16(1) || template.OID() != uint32(2) {
+		t.Fatalf("Incorrect tid (%d) or oid (%d)", template.TID(), template.OID())
+	}
+}
+
+func TestSessionSameTidDistinctOid(t *testing.T) {
+	m1 := &MockTemplate{tid: uint16(1), oid: uint32(2)}
+	m2 := &MockTemplate{tid: uint16(1), oid: uint32(3)}
+	s := New()
+	s.AddTemplate(m1)
+	s.AddTemplate(m2)
+
+	template1, found := s.GetTemplate(m1.TID(), m1.OID())
+	if !found {
+		t.Fatal("Couldn't find expected template")
+	}
+	template2, found := s.GetTemplate(m2.TID(), m2.OID())
+	if !found {
+		t.Fatal("Couldn't find expected template")
+	}
+	if template1.TID() != template2.TID() {
+		t.Fatal("Expected template tids to match")
+	}
+	if template1.OID() == template2.OID() {
+		t.Fatal("Expected template oids to differ")
+	}
+	if s.combinedID(template1.TID(), template1.OID()) == s.combinedID(template2.TID(), template2.OID()) {
+		t.Fatal("Expected session combined IDs to differ")
+	}
+}


### PR DESCRIPTION
From RFC 5101 section 3.4.1:

```
Template ID

      Each of the newly generated Template Records is given a unique
      Template ID.  This uniqueness is local to the Transport Session
      and Observation Domain that generated the Template ID.
```

The template ID is only valid within the scope of an ObservationDomainID, and this commit ensures the same template ID from different ObservationDomainIDs are considered separate.
